### PR TITLE
Add cwd for git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,7 @@ By default, calls the callback with a string containing a changelog from the pre
 
 * `warn` `{function()}` - What warn function to use. For example, `{warn: grunt.log.writeln}`. By default, uses `console.warn`.
 
+* `cwd` `{string}` - The directory that the target repository is checked out in locally.  By default, uses the directory you are executing node in.
+
 ## License
 BSD

--- a/index.js
+++ b/index.js
@@ -7,12 +7,16 @@ var extend = require('lodash.assign');
 module.exports = generate;
 
 function generate(options, done) {
+  var execOptions = {};
+  if(options.cwd)
+    execOptions.cwd = options.cwd;
+
   options = extend({
     version: null,
     to: 'HEAD',
     file: 'CHANGELOG.md',
     subtitle: '',
-    log: console.log.bind(console),
+    log: console.log.bind(console)
   }, options || {});
 
   if (!options.version) {
@@ -22,7 +26,7 @@ function generate(options, done) {
   git.latestTag(function(err, tag) {
     if (err || !tag) return done('Failed to read git tags.\n'+err);
     getChangelogCommits(tag);
-  });
+  }, execOptions);
 
   function getChangelogCommits(latestTag) {
     options.from = options.from || latestTag;
@@ -33,6 +37,7 @@ function generate(options, done) {
     git.getCommits({
       from: options.from, 
       to: options.to,
+      execOptions: execOptions
     }, function(err, commits) {
       if (err) return done('Failed to read git log.\n'+err);
       writeLog(commits);

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,20 +9,20 @@ module.exports = {
 };
 
 //Get latest tag, or if no tag first commit
-function latestTag(done) {
+function latestTag(done, execOptions) {
   //Get tags sorted by date
-  cp.exec("git describe --tags --abbrev=0", function(err, stdout, stderr) {
+  cp.exec("git describe --tags --abbrev=0", execOptions, function(err, stdout, stderr) {
     if (err) {
-      getFirstCommit(done);
+      getFirstCommit(done, execOptions);
     } else {
       done(null, String(stdout).trim());
     }
   });
 }
 
-function getFirstCommit(done) {
+function getFirstCommit(done, execOptions) {
   //Error --> no tag, get first commit
-  cp.exec('git log --format="%H" --pretty=oneline --reverse', function(err, stdout, stderr) {
+  cp.exec('git log --format="%H" --pretty=oneline --reverse', execOptions, function(err, stdout, stderr) {
     if (stderr || !String(stdout).trim()) {
       done('No commits found!');
     } else {
@@ -52,7 +52,7 @@ function getCommits(options, done) {
     options.from ? options.from+'..'+options.to : ''
   );
 
-  return es.child(cp.exec(cmd))
+  return es.child(cp.exec(cmd, options.execOptions))
     .pipe(es.split('\n==END==\n'))
     .pipe(es.map(function(data, cb) {
       var commit = parseRawCommit(data, options);

--- a/lib/git.js
+++ b/lib/git.js
@@ -11,7 +11,7 @@ module.exports = {
 //Get latest tag, or if no tag first commit
 function latestTag(done) {
   //Get tags sorted by date
-  cp.exec("git describe --tags `git rev-list --tags --max-count=1`", function(err, stdout, stderr) {
+  cp.exec("git describe --tags --abbrev=0", function(err, stdout, stderr) {
     if (err) {
       getFirstCommit(done);
     } else {


### PR DESCRIPTION
If you run this utility in any directory other than the directory containing the target git repository you cannot get the data from the target git repository.  By adding a cwd option, the user can now specify which directory to target when gathering tag/commit information.

I also changed the 'latestTag' functionality to work with msysgit.