### PR TITLE
Changes for non-github projects like bitbucket

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -32,8 +32,11 @@ Graphite is a much more available resource than lead, so we use it to lower the 
 fix(pen): use blue ink instead of red ink
 
 ```
+```
 perf(component): Changes the way components are loaded
 
+```
+```
 BREAKING CHANGE: Pen now uses blue ink instead of red.
 
 To migrate, change your code from the following:

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -31,6 +31,9 @@ Graphite is a much more available resource than lead, so we use it to lower the 
 ```
 fix(pen): use blue ink instead of red ink
 
+```
+perf(component): Changes the way components are loaded
+
 BREAKING CHANGE: Pen now uses blue ink instead of red.
 
 To migrate, change your code from the following:
@@ -57,6 +60,8 @@ Is recommended to be one of these. Only **feat** and **fix** show up in the chan
 * **test**: Adding missing tests
 * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
   generation
+* **perf**: A code change for performance enhancements
+  
 
 ### Scope
 The scope could be anything specifying place of the commit change. For example `$location`,

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Generate a changelog from git metadata, using the AngularJS commit conventions.
 
 Adapted from code originally written by @vojtajina and @btford in [grunt-conventional-changelog](https://github.com/btford/grunt-conventional-changelog).
 
+
 ## Example output
 
 - https://github.com/ajoslin/conventional-changelog/blob/master/CHANGELOG.md
@@ -30,6 +31,7 @@ Simple usage:
 ```js
 require('changelog')({
   repository: 'https://github.com/joyent/node',
+  bugs: 'https://company.jira.com/browse/', // By default : repository  + '/commit/'
   version: require('./package.json').version
 }, function(err, log) {
   console.log('Here is your changelog!', log);
@@ -64,9 +66,11 @@ By default, calls the callback with a string containing a changelog from the pre
 
 * `patchVersionText` `{function(version, subtitle)}` - What to use for the title of a patch version in the changelog. Defaults to `'### ' + version + ' ' + subtitle`.
 
-* `commitLink` `{function(commitHash)}` - If repository is provided, this function will be used to link to commits. By default, returns a github commit link based on options.repository: `opts.repository + '/commit/' + hash`
+* `commitLink` `{function(commitHash)}` - If repository is provided, this function will be used to link to commits. By default, returns a github commit link based on options.repository: `opts.repository + '/commit/' + hash` for github
+and `opts.repository + '/commits/' + hash` for bitbucket
 
-* `issueLink` `{function(issueId)}` - If repository is provided, this function will be used to link to issues.  By default, returns a github issue link based on options.repository: `opts.repository + '/issues/' + id`
+
+* `issueLink` `{function(issueId)}` - If "bugs" link is provided, this function will be used to link to issues.  If no "bugs" link is provided, returns the github standard issue link based on options.repository: `opts.repository + '/issues/' + id`
 
 * `log` `{function()}` - What logging function to use. For example, `{log: grunt.log.ok}`. By default, uses `console.log`.
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -38,7 +38,7 @@ function filterExists(data, cb) {
 
 function getCommits(options, done) {
   options = extend({
-    grep: '^feat|^fix|BREAKING',
+    grep: '^feat|^fix|BREAKING|^perf|^refactor',
     format: '%H%n%s%n%b%n==END==',
     from: '',
     to: 'HEAD'
@@ -76,6 +76,7 @@ function parseRawCommit(raw, options) {
   msg.subject = lines.shift();
   msg.closes = [];
   msg.breaks = [];
+  
 
   msg.subject = msg.subject.replace(/\s*(?:Closes|Fixes|Resolves)\s#(\d+)/ig, function(_, i) {
     msg.closes.push(parseInt(i, 10));

--- a/lib/git.js
+++ b/lib/git.js
@@ -38,7 +38,7 @@ function filterExists(data, cb) {
 
 function getCommits(options, done) {
   options = extend({
-    grep: '^feat|^fix|BREAKING|^perf|^refactor',
+    grep: '^feat|^fix|BREAKING|^perf|^refactor|^docs|^style|^test',
     format: '%H%n%s%n%b%n==END==',
     from: '',
     to: 'HEAD'

--- a/lib/git.js
+++ b/lib/git.js
@@ -11,7 +11,7 @@ module.exports = {
 //Get latest tag, or if no tag first commit
 function latestTag(done) {
   //Get tags sorted by date
-  cp.exec("git describe --tags `git rev-list --tags --max-count=1`", function(err, stdout, stderr) {
+  cp.exec("git describe --abbrev=0 --tags", function(err, stdout, stderr) {
     if (err) {
       getFirstCommit(done);
     } else {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -72,9 +72,11 @@ function writeLog(commits, options, done) {
   var sections = {
     fix: {},
     feat: {},
-    breaks: {},
     refactor: {},
-    perf: {}
+    style: {},
+    test: {},
+    perf: {},
+    breaks: {}
   };
 
   commits.forEach(function(commit) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,18 +1,19 @@
+'use strict';
+
 var es = require('event-stream');
 var util = require('util');
 var extend = require('lodash.assign');
 
 var VERSION = '## %s%s';
 var PATCH_VERSION = '### %s%s';
-// var LINK_ISSUE = '[#%s](%s/issues/%s)';
+var LINK_ISSUE = '[#%s](%s/issues/%s)';
 var ISSUE = '(#%s)';
+// var LINK_COMMIT = '[%s](%s/commit/%s)';
 
-// BEGIN use "commits" instead of "commit" for bitbucket 
-var LINK_COMMIT = '[%s](%s/commits/%s)';
-var LINK_ISSUE = 'https://inovasoftware.jira.com/browse/'; // Hacked for special uses
-// END
+var LINK_COMMIT_GITHUB = '[%s](%s/commit/%s)';
+var LINK_COMMIT_BITBUCKET = '[%s](%s/commits/%s)';
 
-// var LINK_COMMIT = '[%s](%s/commit/%s)'; => only work with github
+
 var COMMIT = '(%s)';
 
 module.exports = {
@@ -33,10 +34,28 @@ function getIssueLink(repository, issue) {
     util.format(LINK_ISSUE, issue, repository, issue) :
     util.format(ISSUE, issue);
 }
+
+
+function getCustomIssueLink(bugs, issue) {
+  return bugs ?
+    util.format(LINK_ISSUE, issue, bugs, issue) :
+    util.format(ISSUE, issue);
+
+//    return bugs;
+}
+
+
 function getCommitLink(repository, hash) {
   var shortHash = hash.substring(0,8); // no need to show super long hash in log
+  var link_commit=LINK_COMMIT_GITHUB;
+
+  // Hack for bitbucket
+  if(repository.indexOf("bitbucket") !== -1){
+    link_commit = LINK_COMMIT_BITBUCKET;
+  }
+
   return repository ?
-    util.format(LINK_COMMIT, shortHash, repository, hash) :
+    util.format(link_commit, shortHash, repository, hash) :
     util.format(COMMIT, shortHash);
 }
 
@@ -53,7 +72,9 @@ function writeLog(commits, options, done) {
   var sections = {
     fix: {},
     feat: {},
-    breaks: {}
+    breaks: {},
+    refactor: {},
+    perf: {}
   };
 
   commits.forEach(function(commit) {
@@ -80,6 +101,9 @@ function writeLog(commits, options, done) {
   writer.section('Bug Fixes', sections.fix);
   writer.section('Features', sections.feat);
   writer.section('Breaking Changes', sections.breaks);
+  writer.section('Refactor', sections.refactor);
+  writer.section('Performance Improvements', sections.perf);
+
   writer.end();
 }
 
@@ -88,10 +112,11 @@ var PLAIN_HEADER_TPL = '<a name="%s"></a>\n%s (%s)\n\n';
 var EMPTY_COMPONENT = '$$';
 
 function Writer(stream, options) {
+
   options = extend({
     versionText: getVersion,
     patchVersionText: getPatchVersion,
-    issueLink: getIssueLink.bind(null, options.repository),
+    issueLink: options.bugs ? getCustomIssueLink.bind(null, options.bugs) : getIssueLink.bind(null, options.repository),
     commitLink: getCommitLink.bind(null, options.repository)
   }, options || {});
   

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -4,11 +4,12 @@ var extend = require('lodash.assign');
 
 var VERSION = '## %s%s';
 var PATCH_VERSION = '### %s%s';
-var LINK_ISSUE = '[#%s](%s/issues/%s)';
+// var LINK_ISSUE = '[#%s](%s/issues/%s)';
 var ISSUE = '(#%s)';
 
 // BEGIN use "commits" instead of "commit" for bitbucket 
 var LINK_COMMIT = '[%s](%s/commits/%s)';
+var LINK_ISSUE = 'https://inovasoftware.jira.com/browse/'; // Hacked for special uses
 // END
 
 // var LINK_COMMIT = '[%s](%s/commit/%s)'; => only work with github

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -6,7 +6,12 @@ var VERSION = '## %s%s';
 var PATCH_VERSION = '### %s%s';
 var LINK_ISSUE = '[#%s](%s/issues/%s)';
 var ISSUE = '(#%s)';
-var LINK_COMMIT = '[%s](%s/commit/%s)';
+
+// BEGIN use "commits" instead of "commit" for bitbucket 
+var LINK_COMMIT = '[%s](%s/commits/%s)';
+// END
+
+// var LINK_COMMIT = '[%s](%s/commit/%s)'; => only work with github
 var COMMIT = '(%s)';
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conventional-changelog",
   "codename": "reorder",
-  "version": "https://github.com/bennekrouf/conventional-changelog/tarball/9d46529c934b6293bb6c12cc4f2d1e389e339419",
+  "version": "0.0.11",
   "description": "Generate a markdown changelog from git commit metadata",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conventional-changelog",
   "codename": "reorder",
-  "version": "0.0.11",
+  "version": "https://github.com/bennekrouf/conventional-changelog/tarball/9d46529c934b6293bb6c12cc4f2d1e389e339419",
   "description": "Generate a markdown changelog from git commit metadata",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi

I've been constrained to make some changes to be able to generate log working with bitbucket for managing 2 differences:
- the commit are set in **/commits/** in bitbucket instead of **/commit/**
- issues are logged in a specific JIRA URL (in my case)

I've also added a "perf" section, and it looks like the "refactor" section was not generated. 

I hope my code respects the existing code. If no do not hesitate to ask me for changes, to iterate till the changes can be integrated.

Thanks