### PR TITLE
Option to include chores in the changelog output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ By default, calls the callback with a string containing a changelog from the pre
 
 * `warn` `{function()}` - What warn function to use. For example, `{warn: grunt.log.writeln}`. By default, uses `console.warn`.
 
+* `includeChores` `{boolean}` - Include chores in the changelog. By default, excludes chores.
+
 ## License
 
 BSD

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -47,7 +47,8 @@ function writeLog(commits, options, done) {
   var sections = {
     fix: {},
     feat: {},
-    breaks: {}
+    breaks: {},
+    chore: {}
   };
 
   commits.forEach(function(commit) {
@@ -74,6 +75,9 @@ function writeLog(commits, options, done) {
   writer.section('Bug Fixes', sections.fix);
   writer.section('Features', sections.feat);
   writer.section('Breaking Changes', sections.breaks);
+  if (options.includeChores) {
+    writer.section('Chores', sections.chore);
+  }
   writer.end();
 }
 


### PR DESCRIPTION
I am using your node package (mainly the writer) in my [github changelog](https://www.npmjs.org/package/github-conventional-changelog)
and we want to include the chores in the changelog output.

With this small addition the original behavior won't change but we give the option to include
the chore changes as well.