### PR TITLE
fix(git): support msysgit by using --abbrev flag

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -11,7 +11,7 @@ module.exports = {
 //Get latest tag, or if no tag first commit
 function latestTag(done) {
   //Get tags sorted by date
-  cp.exec("git describe --tags `git rev-list --tags --max-count=1`", function(err, stdout, stderr) {
+  cp.exec("git describe --tags --abbrev=0", function(err, stdout, stderr) {
     if (err) {
       getFirstCommit(done);
     } else {


### PR DESCRIPTION
As discussed in #25. I had a quick Google and didn't find any negative consequences of using this command, but I've only tested this on Windows with msysgit.

Closes #25