### PR TITLE
feat(generate): add function for getting a recommended version bump

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var writer = require('./lib/writer');
 var extend = require('lodash.assign');
 
 module.exports = generate;
+module.exports.bump = bump;
 
 function generate(options, done) {
   options = extend({
@@ -19,6 +20,51 @@ function generate(options, done) {
     return done('No version specified');
   }
 
+  readCommits(options, function writeLog(err, commits) {
+    if (err) return done(err);
+
+    writer.writeLog(commits, options, function(err, changelog) {
+      if (err) return done('Failed to write changelog.\n'+err);
+
+      if (options.file && fs.existsSync(options.file)) {
+        fs.readFile(options.file, {encoding:'UTF-8'}, function(err, contents) {
+          if (err) return done('Failed to read ' + options.file + '.\n'+err);
+          done(null, changelog + '\n' + String(contents));
+        });
+      } else {
+        done(null, changelog);
+      }
+    });
+  });
+}
+
+function bump(options, done) {
+  options = extend({
+    version: null,
+    to: 'HEAD',
+    log: console.log.bind(console),
+  }, options || {});
+
+  readCommits(options, function writeLog(err, commits) {
+    if (err) return done(err);
+
+    var levels = ['major', 'minor', 'patch'];
+    var bump = 2;
+
+    commits.forEach(function (commit) {
+      if (commit.breaks.length) {
+        bump = Math.min(bump, 0);
+      }
+      else if (commit.type === 'feat') {
+        bump = Math.min(bump, 1);
+      }
+    });
+
+    done(null, levels[bump]);
+  });
+}
+
+function readCommits(options, done) {
   git.latestTag(function(err, tag) {
     if (err || tag === undefined) return done('Failed to read git tags.\n'+err);
     getChangelogCommits(tag);
@@ -35,24 +81,9 @@ function generate(options, done) {
       to: options.to,
     }, function(err, commits) {
       if (err) return done('Failed to read git log.\n'+err);
-      writeLog(commits);
-    });
-  }
 
-  function writeLog(commits) {
-    options.log('Parsed %d commits.', commits.length);
-    writer.writeLog(commits, options, function(err, changelog) {
-      if (err) return done('Failed to write changelog.\n'+err);
-
-      if (options.file && fs.existsSync(options.file)) {
-        fs.readFile(options.file, {encoding:'UTF-8'}, function(err, contents) {
-          if (err) return done('Failed to read ' + options.file + '.\n'+err);
-          done(null, changelog + '\n' + String(contents));
-        });
-      } else {
-        done(null, changelog);
-      }
+      options.log('Parsed %d commits.', commits.length);
+      done(null, commits);
     });
   }
 }
-


### PR DESCRIPTION
The conventional changelog provides an excellent guidance on which part of the version number one should bump on release. This commit exposes a `bump` function that looks at the commits and returns a recommendation for either a `major`, `minor`, or `patch` bump.