### PR TITLE
feat(cli): Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Adapted from code originally written by @vojtajina and @btford in [grunt-convent
 ## Roadmap
 
 - Make it return a stream
-- Add a proper command line interface
+- ~~Add a proper command line interface~~
 - Add configurable subjects & sections
 
 ## Documentation
 
-Simple usage: 
+Simple usage:
 
 ```js
 require('conventional-changelog')({
@@ -34,6 +34,35 @@ require('conventional-changelog')({
 }, function(err, log) {
   console.log('Here is your changelog!', log);
 });
+```
+
+Command line usage:
+
+```
+Specify a version as first argument, or use 'next' as version number if no
+version is specified.
+
+Usage
+  changelog
+  changelog <version>
+  changelog <version> --file <filename>
+  changelog <version> --file <filename> --no-write
+
+Options
+  --subtitle    A string to display after the version title in the changelog.
+                For example, it will show "## 1.0.0 "Super Version" if
+                codename "Super Version" is given.
+  --repository  If this is provided, allows issues and commit hashes to be
+                linked to the actual commit. usually used with github
+                repositories. E.g. http://github.com/joyent/node
+  --from        Which commit the changelog should start at. By default, uses
+                previous tag, or if no previous tag the first commit.
+  --to          Which commit the changelog should end at. By default, uses
+                HEAD.
+  --file        A file to read the current changelog from and prepend the new
+                changelog's contents to.
+  --no-write    Don't write back to the file. Used in combination with --file.
+
 ```
 
 #### `changelog(options, callback)`

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+'use strict';
+
+var generate = require('./');
+var fs = require('fs');
+var multiline = require('multiline');
+var pkg = require('./package.json');
+var options = require('minimist')(process.argv.slice(2), {
+  string: [
+    'file',
+    'from',
+    'to',
+    'subtitle',
+    'repository'
+  ],
+  boolean: [
+    'version',
+    'help',
+    'no-write'
+  ]
+});
+
+var args = options._;
+delete options._;
+
+function showHelp() {
+  console.log(multiline(function() {/*
+
+  Generate a changelog from git metadata, using the AngularJS commit
+  conventions.
+
+  Specify a version as first argument, or use 'next' as version number if no
+  version is specified.
+
+  Usage
+    changelog
+    changelog <version>
+    changelog <version> --file <filename>
+    changelog <version> --file <filename> --no-write
+
+  Options
+    --subtitle    A string to display after the version title in the changelog.
+                  For example, it will show "## 1.0.0 "Super Version" if
+                  codename "Super Version" is given.
+    --repository  If this is provided, allows issues and commit hashes to be
+                  linked to the actual commit. usually used with github
+                  repositories. E.g. http://github.com/joyent/node
+    --from        Which commit the changelog should start at. By default, uses
+                  previous tag, or if no previous tag the first commit.
+    --to          Which commit the changelog should end at. By default, uses
+                  HEAD.
+    --file        A file to read the current changelog from and prepend the new
+                  changelog's contents to.
+    --no-write    Don't write back to the file. Used in combination with --file.
+    
+
+  */}));
+}
+
+function toScreen(err, log) {
+  console.log(log);
+}
+
+function toFile(err, log, filename) {
+  fs.writeFileSync(filename, log);
+}
+
+function init(args, options) {
+  if (options.version) {
+    console.log(pkg.version);
+    return;
+  }
+
+  if (options.help) {
+    showHelp();
+    return;
+  }
+
+  var version = args.length ? args[0] : 'next';
+  if (!args.length) {
+    console.warn('No version specified, using "' + version + '"');
+  }
+
+  function callback(err, log) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    if (options.file && !options['no-write']) {
+      toFile(err, log, options.file);
+    } else {
+      toScreen(err, log);
+    }
+  }
+
+  generate({
+    version: version,
+    subtitle: options.subtitle || undefined,
+    from: options.from,
+    to: options.to,
+    repository: options.repository || undefined,
+    file: options.file
+  }, callback);
+}
+
+
+init(args, options);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "changelog"
   ],
   "license": "BSD",
+  "bin": {
+    "changelog": "cli.js"
+  },
   "contributors": [
     {
       "name": "Brian Ford"
@@ -33,7 +36,9 @@
   ],
   "dependencies": {
     "lodash.assign": "~2.4.1",
-    "event-stream": "~3.1.0"
+    "event-stream": "~3.1.0",
+    "minimist": "^1.1.0",
+    "multiline": "^1.0.1"
   },
   "devDependencies": {
     "chai": "~1.7.2",


### PR DESCRIPTION
Add simple command line interface, which can be installed and used globally,
called "changelog". The following is the CLI's help text:

```
  Generate a changelog from git metadata, using the AngularJS commit
  conventions.

  Specify a version as first argument, or use 'next' as version number if no
  version is specified.

  Usage
    changelog
    changelog <version>
    changelog <version> --file <filename>
    changelog <version> --file <filename> --no-write

  Options
    --subtitle    A string to display after the version title in the changelog.
                  For example, it will show "## 1.0.0 "Super Version" if
                  codename "Super Version" is given.
    --repository  If this is provided, allows issues and commit hashes to be
                  linked to the actual commit. usually used with github
                  repositories. E.g. http://github.com/joyent/node
    --from        Which commit the changelog should start at. By default, uses
                  previous tag, or if no previous tag the first commit.
    --to          Which commit the changelog should end at. By default, uses
                  HEAD.
    --file        A file to read the current changelog from and prepend the new
                  changelog's contents to.
    --no-write    Don't write back to the file. Used in combination with --file.
```

If run with no arguments or options, the tool outputs the changelog since last
tag with version number `next`, practical for checking the "current" changelog.
Other options are like the API, except `no-write`, which tells the tool to not
write the new log entires to the file.