### PR TITLE
feat(changelog): add currentVersion, bump options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ By default, calls the callback with a string containing a changelog from the pre
 
 * `warn` `{function()}` - What warn function to use. For example, `{warn: grunt.log.writeln}`. By default, uses `console.warn`.
 
+* `currentVersion` `{string}` - Used with `bump` in place of `version` to automatically increment the version number written to the changelog. Should be a string in the form: `1.2.3`.
+
+* `bump` `{string}` - Used with `currentVersion to automatically increment the version number written to the changelog. Passing `major` increments the major version number, `minor` increments the minor number, and `patch` increments the patch number.
+
 ## License
 
 BSD

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var git = require('./lib/git');
 var writer = require('./lib/writer');
 var extend = require('lodash.assign');
+var versioner = require('./lib/versioner');
 
 module.exports = generate;
 
@@ -13,10 +14,14 @@ function generate(options, done) {
     file: 'CHANGELOG.md',
     subtitle: '',
     log: console.log.bind(console),
+    currentVersion: null,
+    bump: null
   }, options || {});
 
-  if (!options.version) {
+  if (!options.version && !(options.currentVersion && options.bump)) {
     return done('No version specified');
+  } else if (!options.version) {
+    options.version = versioner.nextVersion(options.currentVersion, options.bump);
   }
 
   git.latestTag(function(err, tag) {
@@ -55,4 +60,3 @@ function generate(options, done) {
     });
   }
 }
-

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -1,0 +1,33 @@
+function incrementPatch(version) {
+  var split = version.split('.');
+  split[2] = (parseInt(split[2]) + 1).toString();
+  return split.join('.');
+}
+
+function incrementMinor(version) {
+  var split = version.split('.');
+  split[1] = (parseInt(split[1]) + 1).toString();
+  split[2] = '0';
+  return split.join('.');
+}
+
+function incrementMajor(version) {
+  var split = version.split('.');
+  split[0] = (parseInt(split[0]) + 1).toString();
+  split[1] = '0';
+  split[2] = '0';
+  return split.join('.');
+}
+
+exports.nextVersion = function (currentVersion, bump) {
+  switch (bump) {
+    case 'major':
+      return incrementMajor(currentVersion);
+    case 'minor':
+      return incrementMinor(currentVersion);
+    case 'patch':
+      return incrementPatch(currentVersion);
+    default:
+      throw new Error('Invalid bump value - please use major, minor, or patch');
+  }
+};

--- a/test/versioner.spec.js
+++ b/test/versioner.spec.js
@@ -1,0 +1,25 @@
+var versioner = require('../lib/versioner');
+
+describe('versioner', function () {
+
+  describe('nextVersion', function () {
+
+    it('should increment the major version', function () {
+      expect(versioner.nextVersion('2.1.1', 'major')).to.equal('3.0.0');
+    });
+
+    it('should increment the minor version', function () {
+      expect(versioner.nextVersion('2.1.1', 'minor')).to.equal('2.2.0');
+    });
+
+    it('should increment the patch version', function () {
+      expect(versioner.nextVersion('2.1.1', 'patch')).to.equal('2.1.2');
+    });
+
+    it('should throw an error when a bad bump type is used', function () {
+      expect(function () { versioner.nextVersion('2.1.1', 'super') } ).to.throw(Error);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Allows the currentVersion and bump options to be used in place of the version option. Using these options will automatically increment the version number written to the changelog.

The motivation for this is that conventional-changelog is hard to use with `npm version major/minor/patch` commands. These commands automatically increment the `package.json` version number, make a new commit on the branch, and tag the commit with the latest version. However, you can't run `npm version major/minor/patch` before updating the changelog, because conventional-changelog will parse no commits since a new tag has just been created, and you can't run `npm version major/minor/patch` after conventional-changelog because the version written to the changelog will be the old version.

This feature allows a much easier flow for using this tool with the `npm version` command by allowing the user to pass in the `currentVersion` and `bump` to automatically write a new version to the changelog. The workflow then becomes and easy two-step process:

1. Update the changelog with conventional-changelog passing the current version in `package.json` and `major`, `minor`, or `patch`.
2. Run `npm version major/minor/patch` using the same bump level used when making the changelog.