### PR TITLE
docs(README): add info about running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ By default, calls the callback with a string containing a changelog from the pre
 
 * `warn` `{function()}` - What warn function to use. For example, `{warn: grunt.log.writeln}`. By default, uses `console.warn`.
 
+## Running Tests
+
+To execut all tests with:
+
+    $ npm run tests
+
+You need **mocha** installe globaly:
+
+    $ npm install -g mocha
+
 ## License
 
 BSD


### PR DESCRIPTION
I didn't work with mocha before, and I found that information missing.