### PR TITLE
feat(parseRawCommit): allow for lack of `S` or `:`

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -67,7 +67,7 @@ function parseRawCommit(raw) {
     }
   });
 
-  match = raw.match(/BREAKING CHANGE:\s([\s\S]*)/);
+  match = raw.match(/BREAKING CHANGE(?:|S:|.)\s([\s\S]*)/);
   if (match) {
     msg.breaks.push(match[1] + '\n');
   }


### PR DESCRIPTION
we are human after all

https://github.com/angular/angular/issues/2058

updated regexp
https://regex101.com/r/wZ2oK2/1