### PR TITLE
feat(non-numeric-issue): Add support for non-numeric issues

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -45,21 +45,21 @@ function parseRawCommit(raw) {
   msg.closes = [];
   msg.breaks = [];
 
-  msg.subject = msg.subject.replace(/\s*(?:Closes|Fixes|Resolves)\s#(\d+)/ig, function(_, i) {
-    msg.closes.push(parseInt(i, 10));
+  msg.subject = msg.subject.replace(/\s*(?:Closes|Fixes|Resolves)\s+(.*)/ig, function(_, i) {
+    msg.closes.push(i);
     return '';
   });
 
   lines.forEach(function(line) {
-    match = line.match(/(?:Closes|Fixes|Resolves)\s((?:#\d+(?:\,\s)?)+)/ig);
+    match = line.match(/(?:Closes|Fixes|Resolves)\s+(.*)/ig);
 
     if (match) {
       match.forEach(function(m) {
         if (m) {
-          m.split(',').forEach(function(i) {
-            var issue = i.match(/\d+/);
+          m.replace(/(?:Closes|Fixes|Resolves)\s+/ig, '').split(',').forEach(function(i) {
+            var issue = i.match(/([^\s])+/ig);
             if (issue) {
-              msg.closes.push(parseInt(issue[0], 10));
+              msg.closes.push(issue[0].split('#').join(''));
             }
           });
         }


### PR DESCRIPTION
Issues which do not start with a hash followed by a number are now correctly parsed in the changelog

Closes #59