### PR TITLE
docs(conventions/angular): rearrange sections and fix a few errors

### DIFF
--- a/conventions/angular.md
+++ b/conventions/angular.md
@@ -1,3 +1,27 @@
+#### Examples
+
+Appears under the "Features" header, pencil subheader:
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+Appears under the "Bug Fixes" header, graphite subheader, with a link to issue #28:
+
+```
+fix(graphite): stop grpahite breaking when width < 0.1
+
+Closes #28
+```
+
+Appears under "Performance Improvements" header, and under breaking changes with the breaking change explanation:
+
+```
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
+```
+
 ### Commit Message Format
 
 A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:
@@ -14,30 +38,6 @@ The **header** is mandatory and the **scope** of the header is optional.
 
 Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
 to read on GitHub as well as in various git tools.
-
-#### Examples
-
-Appears under the "Features" header, pencil subheader:
-
-```
-feat(pencil): add 'graphiteWidth' option
-```
-
-Appears under the "Fixes" header, graphite subheader, with a link to issue #28:
-
-```
-fix(graphite): stop grpahite breaking when width < 0.1
-
-Closes #28
-```
-
-Appears under "Features" with the subject, and under breaking changes with the breaking change explanation:
-
-```
-fix(pencil): remove graphiteWidth option
-
-BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used.
-```
 
 ### Revert
 

--- a/conventions/angular.md
+++ b/conventions/angular.md
@@ -22,6 +22,14 @@ perf(pencil): remove graphiteWidth option
 BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
 ```
 
+The following commit and commit `667ecc1` do not appear in the changelog if they are under the same release. If not, the revert commit appears under the "Reverts" header.
+
+```
+revert: feat(pencil): add 'graphiteWidth' option
+
+This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
+```
+
 ### Commit Message Format
 
 A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:


### PR DESCRIPTION
The reason to move examples section up is because it was in the middle of explaining different parts of a commit message.
Also the `perf` example is missing and it was not correct.

@ajoslin would like to review this?