### PR TITLE
add a note about how to list available parameters on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This *will* overwrite any previous changelog if exist.
 
 Or use one of the plugins if you are already using the tool:  [grunt](https://github.com/btford/grunt-conventional-changelog)/[gulp](https://github.com/stevemao/gulp-conventional-changelog)/[atom](https://github.com/stevemao/atom-conventional-changelog)
 
+Note: all available command line parameters can be listed using [CLI](#cli) : `$ conventional-changelog --help # for more details`
 
 ## Recommended workflow
 


### PR DESCRIPTION
Some users want to have all important informations in the README file.
Some developers do not want to repeat themselves ([DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself)).

To balance between these two tendancies, I propose to explain all users how to get easily the list of available parameters on the command line.