### PR TITLE
Fixed linkCompare not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ function conventinalChangelog(options, context, gitRawCommitsOpts, parserOpts, w
               context.currentTag = context.currentTag || 'v' + context.version;
             }
 
-            if (typeof context.linkCompare !== 'boolean' && context.previousTag && context.currentTag) {
+            if (typeof options.linkCompare !== 'boolean' && context.previousTag && context.currentTag) {
               context.linkCompare = true;
             }
 

--- a/index.js
+++ b/index.js
@@ -196,6 +196,8 @@ function conventinalChangelog(options, context, gitRawCommitsOpts, parserOpts, w
 
             if (typeof options.linkCompare !== 'boolean' && context.previousTag && context.currentTag) {
               context.linkCompare = true;
+            } else {
+              context.linkCompare = options.linkCompare;
             }
 
             return context;


### PR DESCRIPTION
linkCompare does not seem to work. This is the only way i could get linkCompare to get picked up properly. Unless there is another way?