### PR TITLE
docs: fixed typo

### DIFF
--- a/conventions/angular.md
+++ b/conventions/angular.md
@@ -9,7 +9,7 @@ feat(pencil): add 'graphiteWidth' option
 Appears under "Bug Fixes" header, graphite subheader, with a link to issue #28:
 
 ```
-fix(graphite): stop grpahite breaking when width < 0.1
+fix(graphite): stop graphite breaking when width < 0.1
 
 Closes #28
 ```


### PR DESCRIPTION
Fixed a typo in the code example. `grpahite` becomes `graphite`