### PR TITLE
[WIP] Add "private" property to repository object

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
           if (match) {
             type = match[0];
           } else {
-            if (pkg.repository.private) {
+            if (pkg && pkg.repository && pkg.repository.private) {
               type = pkg.repository.private;
             }
           }

--- a/index.js
+++ b/index.js
@@ -105,12 +105,12 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
 
           repo = getPkgRepo(pkg);
 
-          if (repo.type) {
+          if (repo.type || repo.host) {
             var browse = repo.browse();
             var parsedBrowse = url.parse(browse);
-            context.host = context.host || parsedBrowse.protocol + (parsedBrowse.slashes ? '//' : '') + repo.domain;
+            context.host = context.host || parsedBrowse.protocol + (parsedBrowse.slashes ? '//' : '') + (repo.domain ? repo.domain : repo.hostname);
             context.owner = context.owner || repo.user;
-            context.repository = context.repository || repo.project;
+            context.repository = context.repository || repo.project || parsedBrowse.path.substring(1);
           }
         } catch (err) {
           options.warn('package.json: "' + options.pkg.path + '" cannot be parsed');
@@ -135,6 +135,10 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
           var match = context.host.match(rhosts);
           if (match) {
             type = match[0];
+          } else {
+            if (pkg.repository.private) {
+              type = pkg.repository.private;
+            }
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -135,10 +135,6 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
           var match = context.host.match(rhosts);
           if (match) {
             type = match[0];
-          } else {
-            if (context.type) {
-              type = context.type;
-            }
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
             type = match[0];
           } else {
             if (context.type) {
-              type = context.type
+              type = context.type;
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -105,12 +105,12 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
 
           repo = getPkgRepo(pkg);
 
-          if (repo.type || repo.host) {
+          if (repo.type || context.host) {
             var browse = repo.browse();
             var parsedBrowse = url.parse(browse);
-            context.host = context.host || parsedBrowse.protocol + (parsedBrowse.slashes ? '//' : '') + (repo.domain ? repo.domain : repo.hostname);
+            context.host = context.host || parsedBrowse.protocol + (parsedBrowse.slashes ? '//' : '') + repo.domain;
             context.owner = context.owner || repo.user;
-            context.repository = context.repository || repo.project || parsedBrowse.path.substring(1);
+            context.repository = context.repository || repo.project;
           }
         } catch (err) {
           options.warn('package.json: "' + options.pkg.path + '" cannot be parsed');
@@ -136,8 +136,8 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
           if (match) {
             type = match[0];
           } else {
-            if (pkg && pkg.repository && pkg.repository.private) {
-              type = pkg.repository.private;
+            if (context.type) {
+              type = context.type
             }
           }
         }


### PR DESCRIPTION
This private property is used as repository type when it is not matched from the repo url.

For example:

"repository": {
    "type": "git",
    "url": "https://on.premises.com/ajoslin/conventional-changelog.git",
    "private": "gitlab"
}

I tested this with JSHint preset and it generated correct paths to the commit and issues.

I am not sure if this is the way to go but i thought i would give it a try.

Relates to #98 