### PR TITLE
chore(tests): add --template . to git init calls

### DIFF
--- a/test/angular.js
+++ b/test/angular.js
@@ -10,7 +10,7 @@ describe('presets', function() {
   describe('angular', function() {
     before(function(done) {
       shell.cd('angular');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m"chore: first commit"');
       writeFileSync('test2', '');

--- a/test/atom.js
+++ b/test/atom.js
@@ -9,7 +9,7 @@ describe('presets', function() {
   describe('atom', function() {
     before(function() {
       shell.cd('atom');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m":arrow_down: exception-reporting"');
       writeFileSync('test2', '');

--- a/test/cli.js
+++ b/test/cli.js
@@ -16,7 +16,7 @@ function originalChangelog() {
 describe('cli', function() {
   before(function() {
     shell.cd('cli');
-    shell.exec('git init');
+    shell.exec('git init --template=../git-templates');
     writeFileSync('test1', '');
     shell.exec('git add --all && git commit -m"First commit"');
   });

--- a/test/codemirror.js
+++ b/test/codemirror.js
@@ -9,7 +9,7 @@ describe('presets', function() {
   describe('codemirror', function() {
     before(function() {
       shell.cd('codemirror');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m"[tern addon] Use correct primary when selecting variables"');
       writeFileSync('test2', '');

--- a/test/ember.js
+++ b/test/ember.js
@@ -10,7 +10,7 @@ describe('presets', function() {
   describe('ember', function() {
     before(function(done) {
       shell.cd('ember');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       child.exec('git add --all && git commit -m"Merge pull request #12001 from rwjblue/remove-with-controller\n\n[CLEANUP beta] Remove {{with}} keyword\'s controller option. Closes #1"', function() {
         writeFileSync('test2', '');

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -9,7 +9,7 @@ describe('presets', function() {
   describe('eslint', function() {
     before(function() {
       shell.cd('eslint');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m\'Fix: the `no-class-assign` rule (fixes #2718)\'');
       writeFileSync('test2', '');

--- a/test/express.js
+++ b/test/express.js
@@ -10,7 +10,7 @@ describe('presets', function() {
   describe('express', function() {
     before(function(done) {
       shell.cd('express');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       child.exec('git add --all && git commit -m"deps: type-is@~1.6.3\n\n - deps: mime-types@~2.1.1\n - perf: reduce try block size\n - perf: remove bitwise operations"', function() {
         writeFileSync('test2', '');

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -9,7 +9,7 @@ describe('presets', function() {
   describe('jquery', function() {
     before(function() {
       shell.cd('jquery');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m"Core: Make jQuery objects iterable"');
       writeFileSync('test2', '');

--- a/test/jscs.js
+++ b/test/jscs.js
@@ -9,7 +9,7 @@ describe('presets', function() {
   describe('jscs', function() {
     before(function() {
       shell.cd('jscs');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m"disallowKeywordsOnNewLine: Allow comments before keywords"');
       writeFileSync('test2', '');

--- a/test/jshint.js
+++ b/test/jshint.js
@@ -10,7 +10,7 @@ describe('presets', function() {
   describe('jshint', function() {
     before(function(done) {
       shell.cd('jshint');
-      shell.exec('git init');
+      shell.exec('git init --template=../git-templates');
       writeFileSync('test1', '');
       shell.exec('git add --all && git commit -m"[[Chore]] Move scope-manager to external file"');
       writeFileSync('test2', '');

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -5,6 +5,7 @@ shell.rm('-rf', 'tmp');
 shell.mkdir('tmp');
 shell.cd('tmp');
 
+shell.mkdir('git-templates');
 shell.mkdir('test');
 shell.mkdir('angular');
 shell.mkdir('jquery');

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ var writeFileSync = require('fs').writeFileSync;
 describe('conventionalChangelog', function() {
   before(function() {
     shell.cd('test');
-    shell.exec('git init');
+    shell.exec('git init --template=../git-templates');
     writeFileSync('test1', '');
     shell.exec('git add --all && git commit -m"First commit"');
   });


### PR DESCRIPTION
This fixes issues with tests, if local system has git templates defined, commit-msg hooks which should confirm that commit messages are valid etc. causing tests to fail.