### PR TITLE
feat(preset): add dynamic preset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Returns a readable stream.
 
 ##### preset
 
-Type: `string` [Possible values](presets)
+Type: `string` [Default values](presets) or any valid absolute or relative path
 
 It's recommended to use a preset so you don't have to define everything yourself. The preset values can be overwritten.
 

--- a/index.js
+++ b/index.js
@@ -63,11 +63,11 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
   var loadPreset = options.preset;
 
   if (loadPreset) {
-    var avaliblePresets = fs.readdirSync('./presets/');
     try {
+      var avaliblePresets = fs.readdirSync(__dirname + '/presets/');
       loadPreset = (avaliblePresets.indexOf(loadPreset + '.js') > -1) ?
-        './presets/' + options.preset;
-        path.resolve(process.cwd(), options.preset):
+        './presets/' + options.preset :
+        path.resolve(process.cwd(), options.preset);
 
       var presetFn = require(loadPreset);
 

--- a/index.js
+++ b/index.js
@@ -69,9 +69,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
         './presets/' + options.preset :
         path.resolve(process.cwd(), options.preset);
 
-      var presetFn = require(loadPreset);
-
-      presetPromise = Q.nfcall(presetFn);
+      presetPromise = Q.nfcall(require(loadPreset));
     } catch (err) {
       loadPreset = false;
       options.warn('Preset: "' + options.preset + '" does not exist');

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var readPkgUp = require('read-pkg-up');
 var stream = require('stream');
 var through = require('through2');
 var url = require('url');
+var path = require('path');
 var _ = require('lodash');
 
 var rhosts = /github|bitbucket|gitlab/i;
@@ -61,8 +62,12 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
   var loadPreset = options.preset;
 
   if (loadPreset) {
+    var parsedPresetPath = path.parse(loadPreset);
     try {
-      var presetFn = require('./presets/' + options.preset);
+      var presetFn = (parsedPresetPath.root || parsedPresetPath.dir) ?
+        require(options.preset) :
+        require('./presets/' + options.preset);
+
       presetPromise = Q.nfcall(presetFn);
     } catch (err) {
       loadPreset = false;

--- a/index.js
+++ b/index.js
@@ -10,8 +10,9 @@ var readPkg = require('read-pkg');
 var readPkgUp = require('read-pkg-up');
 var stream = require('stream');
 var through = require('through2');
-var url = require('url');
+var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var _ = require('lodash');
 
 var rhosts = /github|bitbucket|gitlab/i;
@@ -62,11 +63,13 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
   var loadPreset = options.preset;
 
   if (loadPreset) {
-    var parsedPresetPath = path.parse(loadPreset);
+    var avaliblePresets = fs.readdirSync('./presets/');
     try {
-      var presetFn = (parsedPresetPath.root || parsedPresetPath.dir) ?
-        require(options.preset) :
-        require('./presets/' + options.preset);
+      loadPreset = (avaliblePresets.indexOf(loadPreset + '.js') > -1) ?
+        './presets/' + options.preset;
+        path.resolve(process.cwd(), options.preset):
+
+      var presetFn = require(loadPreset);
 
       presetPromise = Q.nfcall(presetFn);
     } catch (err) {


### PR DESCRIPTION
It possible load dynamic preset js.

Example:
```
conventional-changelog -p ./presets/custom -i CHANGELOG.md -w -r 0
conventional-changelog -p /foo/bar/presets/custom -i CHANGELOG.md -w -r 0
```
and the default behavior is work to (load conventional-changelog/presets/...):
```
conventional-changelog -p angular -i CHANGELOG.md -w -r 0
```