### PR TITLE
docs(conventions/angular): add `docs` type prefix

### DIFF
--- a/conventions/angular.md
+++ b/conventions/angular.md
@@ -55,7 +55,7 @@ If the commit reverts a previous commit, it should begin with `revert: `, follow
 
 If the prefix is `feat`, `fix` or `perf`, it will always appear in the changelog.
 
-Other prefixes are up to your discretion. Suggested prefixes are `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+Other prefixes are up to your discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
 
 ### Scope
 


### PR DESCRIPTION
Angular's [guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type) list `docs` as one of their compulsory set of type prefixes, and it is currently the only one listed there that is not documented here.

On a related note, perhaps it would be good to highlight any differences between conventional-changelog's interpretation and the actual Angular spec.
