### PR TITLE
fix(options): fix losing parserOpts without preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
       }
 
       parserOpts = _.assign(
-        preset.parserOpts, {
+        {}, preset.parserOpts, {
           warn: options.warn
         },
         parserOpts);

--- a/test/test.js
+++ b/test/test.js
@@ -743,4 +743,25 @@ describe('conventionalChangelog', function() {
         done();
       }));
   });
+
+  it('should pass `parserOpts` to conventional-commits-parser', function(done) {
+    writeFileSync('test9', '');
+    shell.exec('git add --all && git commit -m"test9" -m"Release note: super release!"');
+
+    conventionalChangelog({}, {}, {}, {
+      noteKeywords: [
+        'Release note'
+      ]
+    })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.include('* test9');
+        expect(chunk).to.include('### Release note\n\n* super release!');
+
+        cb();
+      }, function() {
+        done();
+      }));
+  });
 });


### PR DESCRIPTION
`preset.parserOpts` may be undefined if no preset was specified in the
options. `_.assign()` will return `undefined` if the first argument is
`undefined`.