### PR TITLE
feat(preset): Relax JSHint message requirements

### DIFF
--- a/presets/jshint.js
+++ b/presets/jshint.js
@@ -18,9 +18,11 @@ function presetOpts(cb) {
 
   var writerOpts = {
     transform: function(commit) {
-      if (commit.type === 'FEAT') {
+      var type = commit.type ? commit.type.toUpperCase() : '';
+
+      if (type === 'FEAT') {
         commit.type = 'Features';
-      } else if (commit.type === 'FIX') {
+      } else if (type === 'FIX') {
         commit.type = 'Bug Fixes';
       } else {
         return;

--- a/test/jshint.js
+++ b/test/jshint.js
@@ -17,6 +17,7 @@ describe('presets', function() {
       shell.exec('git add --all && git commit -m"[[Test]] Add test for gh-985. Fixes #985"');
       writeFileSync('test3', '');
       shell.exec('git add --all && git commit -m"[[FIX]] catch params are scoped to the catch only"');
+      shell.exec('git commit --allow-empty -m"[[Fix]] accidentally use lower-case"');
       writeFileSync('test4', '');
       child.exec('git add --all && git commit -m"[[FEAT]] Option to assume strict mode\n\nBREAKING CHANGE: Not backward compatible."', function() {
         writeFileSync('test5', '');
@@ -40,6 +41,7 @@ describe('presets', function() {
           expect(chunk).to.include('catch params are scoped to the catch only');
           expect(chunk).to.include('### Bug Fixes');
           expect(chunk).to.include('Option to assume strict mode');
+          expect(chunk).to.include('accidentally use lower-case');
           expect(chunk).to.include('### Features');
           expect(chunk).to.include('BREAKING CHANGES');
 


### PR DESCRIPTION
Accept any character case when parsing commit type.