### PR TITLE
feat(changelog): Can specify a readable stream a commits source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ $ npm install --global conventional-changelog
 $ conventional-changelog --help # for more details
 ```
 
+#### Generating logs to use with --from-file
+
+```sh
+$ git log --format="%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci%n------------------------ >8 ------------------------" > logs.txt
+$ conventional-changelog -f logs.txt
+```
 
 ## Notes for parent modules
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
     },
     append: false,
     releaseCount: 1,
+    commitsStream: null,
     warn: function() {},
     transform: function(commit, cb) {
       if (typeof commit.gitTags === 'string') {
@@ -86,6 +87,7 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
       var pkg;
       var tag;
       var repo;
+      var commitsStream;
 
       var hostOpts;
 
@@ -221,11 +223,17 @@ function conventionalChangelog(options, context, gitRawCommitsOpts, parserOpts, 
         writerOpts
       );
 
-      gitRawCommits(gitRawCommitsOpts)
-        .on('error', function(err) {
-          err.message = 'Error in git-raw-commits: ' + err.message;
-          readable.emit('error', err);
-        })
+      if (options.commitsStream) {
+        commitsStream = options.commitsStream;
+      } else {
+        commitsStream = gitRawCommits(gitRawCommitsOpts)
+          .on('error', function (err) {
+            err.message = 'Error in git-raw-commits: ' + err.message;
+            readable.emit('error', err);
+          });
+      }
+
+      commitsStream
         .pipe(conventionalCommitsParser(parserOpts))
         .on('error', function(err) {
           err.message = 'Error in conventional-commits-parser: ' + err.message;


### PR DESCRIPTION
We had a need to specify commits from a stream or file rather than using a git repo, so this PR adds an extension point for specifying the source of the commits.

CLI has been updated to add --from-file (-f) and --delimiter (-d) to specify a commits file.